### PR TITLE
Create a basic DUB snap package with classic confinement

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@ dub.snap
 ========
 
 This project defines a snap package for DUB, a package and build manager
-for the D programming language.
+for the D programming language.  It is an 'external' snap, meaning that
+it downloads and builds the source from the official DUB git repo.  For
+more information on DUB, see: https://github.com/dlang/dub
 
 The D programming language is a systems programming language with C-like
 syntax and static typing.  It combines efficiency, control and modelling
@@ -13,3 +15,35 @@ Snap packages are designed to provide secure, containerized applications
 that are appropriately sandboxed away from the rest of the system they
 are running on.  For more information on snap packages, see:
 http://snapcraft.io/
+
+
+Building
+--------
+
+On Ubuntu 16.04 or higher with snapcraft installed
+(`sudo apt install snapcraft`):
+
+    git clone https://github.com/WebDrake/dub.snap.git
+    cd dub.snap
+    snapcraft
+
+Since DUB is packaged as a `classic` snap, the `snapcraft cleanbuild`
+command is not currently supported.  This is expected to be fixed with
+upcoming releases of `snapcraft`, so try it if you like, just don't be
+surprised if it fails with linker errors.
+
+
+Installing
+----------
+
+DUB has been packaged as a `classic` snap, so installing it requires the
+`--classic` flag to be used in order to grant the necessary confinement
+permissions.  Self-built snaps are unsigned and therefore also require
+the `--dangerous` flag in order to install them:
+
+    sudo snap install --classic --dangerous dub_VERSION_amd64.snap
+
+replacing `VERSION` as appropriate.
+
+For more information on `classic` confinement, see:
+https://insights.ubuntu.com/2017/01/09/how-to-snap-introducing-classic-confinement/

--- a/snap/license.txt
+++ b/snap/license.txt
@@ -1,0 +1,7 @@
+Copyright (c) 2012-2016 RejectedSoftware e.K.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/snap/plugins/dub.py
+++ b/snap/plugins/dub.py
@@ -1,0 +1,109 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (c) 2016 Joseph Rushton Wakeling
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""The DUB plugin can be used for D language projects that can be built
+with the command `dub build`.
+
+Since the DUB package/build manager does not currently have an `install`
+option, some manual work may be necessary to ensure snapcraft correctly
+packages the executables and libraries that have been built.  By default
+the plugin will copy the contents of the entire project build directory,
+including both built files and the source of the project being built;
+these files can be filtered in the usual way using the `snap:` config
+option in `snapcraft.yaml`.
+
+If the DUB build target includes a `targetPath` in the DUB config file,
+then this can be specified in `snapcraft.yaml` using the corresponding
+`target-path` plugin config option.  In this case, the plugin will copy
+only files placed in that directory.
+
+The complete list of plugin-specific keywords is as follows:
+
+    - build-flags:
+      (array)
+      List of flags to pass to the `dub build` command, such as
+      `--build=release` or `--compiler=ldc2`.
+
+    - build-target:
+      (string)
+      The specific target to build, of those defined in `dub.json`.
+      Optional, since many projects do not define multiple targets.
+
+    - target-path:
+      (string)
+      Directory (relative to the base directory of the project)
+      where DUB is expected to write built files; corresponds to
+      the `targetPath` variable in `dub.json`.  This can be used
+      to filter the files that the plugin will attempt to install
+      as part of the snap.  Optional, since many projects will
+      not define any `targetPath`.
+"""
+
+import os
+import shutil
+import snapcraft
+
+class DubPlugin(snapcraft.BasePlugin):
+
+    @classmethod
+    def schema(cls):
+        schema = super().schema()
+        # flags to pass to the `dub build` command
+        # (e.g. --build=release, --compiler=ldc2)
+        schema['properties']['build-flags'] = {
+            'type': 'array',
+            'minitems': 1,
+            'uniqueItems': True,
+            'items': {
+                'type': 'string',
+            },
+            'default': [],
+        }
+        # the dub target to build (optional)
+        schema['properties']['build-target'] = {
+            'type': 'string',
+            'default': ''
+        }
+        # the target path where dub will place files
+        # that have been built, relative to the root
+        # of the dub package's source tree
+        schema['properties']['target-path'] = {
+            'type': 'string',
+            'default': ''
+        }
+        return schema
+
+    def __init__(self, name, options, project):
+        super().__init__(name, options, project)
+        self.build_packages.append('dub')
+
+    def build(self):
+        super().build()
+
+        # Handle the build type and config, and run the
+        # corresponding `dub` command
+        self.run(['dub', 'build', self.options.build_target]
+                 + self.options.build_flags)
+
+        # Copy files from the build dir to the install dir
+        # (necessary since dub has no `install` command of
+        # its own)
+        dub_target_dir = os.path.join(self.partdir, 'build',
+                                      self.options.target_path)
+        for entry in os.scandir(dub_target_dir):
+            if entry.is_file() or entry.is_dir():
+                entry_path = os.path.join(dub_target_dir, entry.name)
+                shutil.copy2(entry_path, self.installdir)

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,36 @@
+name: dub
+version: 1.1.2
+summary: Package and build manager for D applications and libraries
+description: |
+    DUB is a build tool for projects written in the D programming
+    language, with support for automatically retrieving dependencies
+    and integrating them into the build process.
+confinement: classic
+grade: devel
+
+apps:
+  dub:
+    command: dub
+
+parts:
+  dub:
+    source: https://github.com/dlang/dub.git
+    source-tag: v1.1.2
+    plugin: dub
+    build-flags:
+    - --build=release
+    - --compiler=ldc2
+    - --config=application
+    - --force
+    - --verbose
+    target-path: bin
+    organize:
+      dub: bin/dub
+    prime:
+    - -libcurl.dll
+    - -libeay32.dll
+    - -ssleay32.dll
+    build-packages:
+    - build-essential
+    - ldc
+    - libcurl4-gnutls-dev


### PR DESCRIPTION
This new PR supersedes that provided in https://github.com/WebDrake/dub.snap/pull/2 to ensure that README info related to the design of the snap package is provided only after `snapcraft.yaml` is defined.

It also corrects some issues with the earlier PR, most notably the lack of summary and description in `snapcraft.yaml`.