### PR TITLE
Create a classic snap for DUB without bootstrapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@ dub.snap
 ========
 
 This project defines a snap package for DUB, a package and build manager
-for the D programming language.
+for the D programming language.  It is an 'external' snap, meaning that
+it downloads and builds the source from the official DUB git repo.  For
+more information on DUB, see: https://github.com/dlang/dub
 
 The D programming language is a systems programming language with C-like
 syntax and static typing.  It combines efficiency, control and modelling
@@ -13,3 +15,35 @@ Snap packages are designed to provide secure, containerized applications
 that are appropriately sandboxed away from the rest of the system they
 are running on.  For more information on snap packages, see:
 http://snapcraft.io/
+
+
+Building
+--------
+
+On Ubuntu 16.04 or higher with snapcraft installed
+(`sudo apt install snapcraft`):
+
+    git clone https://github.com/WebDrake/dub.snap.git
+    cd dub.snap
+    snapcraft
+
+Since DUB is packaged as a `classic` snap, the `snapcraft cleanbuild`
+command is not currently supported.  This is expected to be fixed with
+upcoming releases of `snapcraft`, so try it if you like, just don't be
+surprised if it fails with linker errors.
+
+
+Installing
+----------
+
+DUB has been packaged as a `classic` snap, so installing it requires the
+`--classic` flag to be used in order to grant the necessary confinement
+permissions.  Self-built snaps are unsigned and therefore also require
+the `--dangerous` flag in order to install them:
+
+    sudo snap install --classic --dangerous dub_VERSION_amd64.snap
+
+replacing `VERSION` as appropriate.
+
+For more information on `classic` confinement, see:
+https://insights.ubuntu.com/2017/01/09/how-to-snap-introducing-classic-confinement/

--- a/snap/license.txt
+++ b/snap/license.txt
@@ -1,0 +1,7 @@
+Copyright (c) 2012-2016 RejectedSoftware e.K.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/snap/plugins/builddub.py
+++ b/snap/plugins/builddub.py
@@ -1,0 +1,72 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (c) 2016 Joseph Rushton Wakeling
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""This plugin is intended solely for the purposes of building DUB, and
+is not for general purpose usage.  It simply invokes the build script
+`build.sh`, using the specified D compiler.
+
+There is one plugin-specific keyword:
+
+    - d-compiler:
+     (string)
+     The D compiler to use: dmd, gdc, gdmd or ldmd2.
+"""
+
+import os
+import shutil
+import snapcraft
+
+class BuildDubPlugin(snapcraft.BasePlugin):
+
+    @classmethod
+    def schema(cls):
+        schema = super().schema()
+        # the D compiler to use: dmd, gdc, gdmd
+        # or ldmd2
+        schema['properties']['d-compiler'] = {
+            'type': 'string',
+            'default': ''
+        }
+        return schema
+
+    def __init__(self, name, options, project):
+        super().__init__(name, options, project)
+
+    def build(self):
+        super().build()
+
+        env=self._build_environment()
+
+        build_script = './build.sh'
+
+        if self.options.d_compiler == 'gdc':
+            build_script = './build-gdc.sh'
+
+        # Handle the build type and config, and run the
+        # corresponding `dub` command
+        self.run([build_script], env=env)
+
+        # Copy `dub` executable into the install directory
+        dub_install_path = os.path.join(self.installdir, 'bin')
+        os.mkdir(dub_install_path)
+        dub_path = os.path.join(self.partdir, 'build', 'bin', 'dub')
+        shutil.copy2(os.path.join(self.partdir, 'build', 'bin', 'dub'),
+                     dub_install_path)
+
+    def _build_environment(self):
+        env = os.environ.copy()
+        env['DMD'] = self.options.d_compiler
+        return env

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,24 @@
+name: dub
+version: 1.1.2
+summary: Package and build manager for D applications and libraries
+description: |
+    DUB is a build tool for projects written in the D programming
+    language, with support for automatically retrieving dependencies
+    and integrating them into the build process.
+confinement: classic
+grade: devel
+
+apps:
+  dub:
+    command: dub
+
+parts:
+  dub:
+    source: https://github.com/dlang/dub.git
+    source-tag: v1.1.2
+    plugin: builddub
+    d-compiler: ldmd2
+    build-packages:
+    - build-essential
+    - ldc
+    - libcurl4-gnutls-dev


### PR DESCRIPTION
This PR provides an alternative to the design in https://github.com/WebDrake/dub.snap/pull/3 and its predecessors, replacing the `dub.py` plugin (which requires dub itself as a build dependency) with a simpler and more specific custom plugin whose sole purpose is to invoke the `build.sh` script.

This removes any requirement to have DUB already pre-packaged, while allowing some customization with respect to which D compiler is used.